### PR TITLE
feat: 일손 모집 공고 모델 및 서비스 구현 #18

### DIFF
--- a/lib/core/models/job_posting_model.dart
+++ b/lib/core/models/job_posting_model.dart
@@ -1,0 +1,85 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'job_posting_model.g.dart';
+
+// API 응답에서 작성자 정보를 담는 모델
+@JsonSerializable()
+class AuthorInfo {
+  final int id;
+  final String name;
+  final String nickname;
+  final String? phone;
+  final String? email;
+
+  AuthorInfo({
+    required this.id,
+    required this.name,
+    required this.nickname,
+    this.phone,
+    this.email,
+  });
+
+  factory AuthorInfo.fromJson(Map<String, dynamic> json) =>
+      _$AuthorInfoFromJson(json);
+  Map<String, dynamic> toJson() => _$AuthorInfoToJson(this);
+}
+
+// 일손 모집 공고 목록 또는 상세 정보 응답을 위한 모델
+@JsonSerializable()
+class JobPostingResponse {
+  final int id;
+  final String title;
+  final String? description;
+  final String farmName;
+  final String address;
+  final double latitude;
+  final double longitude;
+  final String cropType;
+  final String cropTypeName;
+  final String workType;
+  final String workTypeName;
+  final int wages;
+  final String wageType;
+  final String wageTypeName;
+  final String workStartDate;
+  final String workEndDate;
+  final int recruitmentCount;
+  final String? contactPhone;
+  final String? contactEmail;
+  final String status;
+  final String statusName;
+  final AuthorInfo author;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  JobPostingResponse({
+    required this.id,
+    required this.title,
+    this.description,
+    required this.farmName,
+    required this.address,
+    required this.latitude,
+    required this.longitude,
+    required this.cropType,
+    required this.cropTypeName,
+    required this.workType,
+    required this.workTypeName,
+    required this.wages,
+    required this.wageType,
+    required this.wageTypeName,
+    required this.workStartDate,
+    required this.workEndDate,
+    required this.recruitmentCount,
+    this.contactPhone,
+    this.contactEmail,
+    required this.status,
+    required this.statusName,
+    required this.author,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  factory JobPostingResponse.fromJson(Map<String, dynamic> json) =>
+      _$JobPostingResponseFromJson(json);
+  Map<String, dynamic> toJson() => _$JobPostingResponseToJson(this);
+}

--- a/lib/core/models/job_posting_model.g.dart
+++ b/lib/core/models/job_posting_model.g.dart
@@ -1,0 +1,80 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'job_posting_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+AuthorInfo _$AuthorInfoFromJson(Map<String, dynamic> json) => AuthorInfo(
+  id: (json['id'] as num).toInt(),
+  name: json['name'] as String,
+  nickname: json['nickname'] as String,
+  phone: json['phone'] as String?,
+  email: json['email'] as String?,
+);
+
+Map<String, dynamic> _$AuthorInfoToJson(AuthorInfo instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'nickname': instance.nickname,
+      'phone': instance.phone,
+      'email': instance.email,
+    };
+
+JobPostingResponse _$JobPostingResponseFromJson(Map<String, dynamic> json) =>
+    JobPostingResponse(
+      id: (json['id'] as num).toInt(),
+      title: json['title'] as String,
+      description: json['description'] as String?,
+      farmName: json['farmName'] as String,
+      address: json['address'] as String,
+      latitude: (json['latitude'] as num).toDouble(),
+      longitude: (json['longitude'] as num).toDouble(),
+      cropType: json['cropType'] as String,
+      cropTypeName: json['cropTypeName'] as String,
+      workType: json['workType'] as String,
+      workTypeName: json['workTypeName'] as String,
+      wages: (json['wages'] as num).toInt(),
+      wageType: json['wageType'] as String,
+      wageTypeName: json['wageTypeName'] as String,
+      workStartDate: json['workStartDate'] as String,
+      workEndDate: json['workEndDate'] as String,
+      recruitmentCount: (json['recruitmentCount'] as num).toInt(),
+      contactPhone: json['contactPhone'] as String?,
+      contactEmail: json['contactEmail'] as String?,
+      status: json['status'] as String,
+      statusName: json['statusName'] as String,
+      author: AuthorInfo.fromJson(json['author'] as Map<String, dynamic>),
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      updatedAt: DateTime.parse(json['updatedAt'] as String),
+    );
+
+Map<String, dynamic> _$JobPostingResponseToJson(JobPostingResponse instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'title': instance.title,
+      'description': instance.description,
+      'farmName': instance.farmName,
+      'address': instance.address,
+      'latitude': instance.latitude,
+      'longitude': instance.longitude,
+      'cropType': instance.cropType,
+      'cropTypeName': instance.cropTypeName,
+      'workType': instance.workType,
+      'workTypeName': instance.workTypeName,
+      'wages': instance.wages,
+      'wageType': instance.wageType,
+      'wageTypeName': instance.wageTypeName,
+      'workStartDate': instance.workStartDate,
+      'workEndDate': instance.workEndDate,
+      'recruitmentCount': instance.recruitmentCount,
+      'contactPhone': instance.contactPhone,
+      'contactEmail': instance.contactEmail,
+      'status': instance.status,
+      'statusName': instance.statusName,
+      'author': instance.author,
+      'createdAt': instance.createdAt.toIso8601String(),
+      'updatedAt': instance.updatedAt.toIso8601String(),
+    };

--- a/lib/core/services/job_posting_service.dart
+++ b/lib/core/services/job_posting_service.dart
@@ -1,0 +1,45 @@
+import 'package:jejunongdi/core/models/job_posting_model.dart';
+import 'package:jejunongdi/core/network/api_client.dart';
+import 'package:jejunongdi/core/network/api_exceptions.dart';
+import 'package:jejunongdi/core/utils/logger.dart';
+
+class JobPostingService {
+  static JobPostingService? _instance;
+  final ApiClient _apiClient = ApiClient.instance;
+
+  static JobPostingService get instance {
+    _instance ??= JobPostingService._internal();
+    return _instance!;
+  }
+
+  JobPostingService._internal();
+
+  /// 전체 일손 모집 공고 목록을 가져옵니다.
+  Future<ApiResult<List<JobPostingResponse>>> getJobPostings() async {
+    try {
+      Logger.info('일손 모집 공고 목록 조회 시도');
+
+      // GET 요청으로 공고 목록 데이터를 받아옵니다.
+      final response = await _apiClient.get<List<dynamic>>('/api/job-postings');
+
+      if (response.data != null) {
+        // 받아온 List<dynamic> 데이터를 List<JobPostingResponse>로 변환합니다.
+        final jobPostings = response.data!
+            .map((item) => JobPostingResponse.fromJson(item as Map<String, dynamic>))
+            .toList();
+
+        Logger.info('일손 모집 공고 목록 조회 성공: ${jobPostings.length}개');
+        return ApiResult.success(jobPostings);
+      } else {
+        return ApiResult.failure(const UnknownException('공고 목록 응답 데이터가 없습니다.'));
+      }
+    } catch (e) {
+      Logger.error('일손 모집 공고 목록 조회 실패', error: e);
+      if (e is ApiException) {
+        return ApiResult.failure(e);
+      } else {
+        return ApiResult.failure(UnknownException('공고 목록 조회 중 오류가 발생했습니다: $e'));
+      }
+    }
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #18 
## 📝작업 내용

> - `job_posting_model.dart`: 일손 모집 공고 목록 및 상세 정보 응답을 위한 `JobPostingResponse` 모델과 작성자 정보를 담는 `AuthorInfo` 모델을 정의했습니다. `json_serializable`을 사용하여 `fromJson`과 `toJson` 메서드를 구현했습니다.
- `job_posting_service.dart`: `getJobPostings` 메서드를 통해 전체 일손 모집 공고 목록을 가져오는 기능을 구현했습니다. `ApiClient`를 사용하여 GET 요청을 보내고, 응답 데이터를 `JobPostingResponse` 모델 리스트로 변환합니다. API 요청/응답 과정에서 발생할 수 있는 예외를 처리하고 `ApiResult`를 통해 결과를 반환합니다.
- `job_posting_model.g.dart`: `json_serializable`을 통해 자동 생성된 파일입니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 검토 후 merge 부탁드립니다!