### PR TITLE
feat: 공고 상세 페이지 구현 및 연동

### DIFF
--- a/lib/core/services/job_posting_service.dart
+++ b/lib/core/services/job_posting_service.dart
@@ -139,4 +139,31 @@ class JobPostingService {
       }
     }
   }
+
+  Future<ApiResult<JobPostingResponse>> getJobPostingById(int jobPostingId) async {
+    try {
+      Logger.info('ID($jobPostingId)로 공고 상세 정보 조회 시도');
+
+      // GET 요청으로 특정 공고 데이터를 받아옵니다.
+      final response = await _apiClient.get<Map<String, dynamic>>(
+        '/api/job-postings/$jobPostingId',
+      );
+
+      if (response.data != null) {
+        // 받아온 데이터를 JobPostingResponse 모델로 변환합니다.
+        final jobPosting = JobPostingResponse.fromJson(response.data!);
+        Logger.info('공고 상세 정보 조회 성공: ${jobPosting.title}');
+        return ApiResult.success(jobPosting);
+      } else {
+        return ApiResult.failure(const UnknownException('공고 상세 정보 응답 데이터가 없습니다.'));
+      }
+    } catch (e) {
+      Logger.error('공고 상세 정보 조회 실패', error: e);
+      if (e is ApiException) {
+        return ApiResult.failure(e);
+      } else {
+        return ApiResult.failure(UnknownException('공고 상세 정보 조회 중 오류가 발생했습니다: $e'));
+      }
+    }
+  }
 }

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -6,6 +6,7 @@ import 'package:jejunongdi/core/services/job_posting_service.dart';
 import 'package:jejunongdi/core/utils/logger.dart';
 import 'package:jejunongdi/screens/widgets/job_posting_detail_sheet.dart';
 import 'package:jejunongdi/screens/job_list_screen.dart';
+import 'package:jejunongdi/screens/job_posting_detail_screen.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -148,13 +149,10 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   void _showJobPostingDetails(JobPostingResponse jobPosting) {
-    showModalBottomSheet(
-      context: context,
-      isScrollControlled: true,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) => JobPostingDetailScreen(jobPostingId: jobPosting.id),
       ),
-      builder: (context) => JobPostingDetailSheet(jobPosting: jobPosting),
     );
   }
 

--- a/lib/screens/job_list_screen.dart
+++ b/lib/screens/job_list_screen.dart
@@ -4,6 +4,7 @@ import 'package:jejunongdi/core/models/job_posting_model.dart';
 import 'package:jejunongdi/core/services/job_posting_service.dart';
 import 'package:jejunongdi/core/utils/logger.dart';
 import 'package:jejunongdi/screens/widgets/job_posting_detail_sheet.dart';
+import 'package:jejunongdi/screens/job_posting_detail_screen.dart';
 
 class JobListScreen extends StatefulWidget {
   const JobListScreen({super.key});
@@ -317,7 +318,13 @@ class _JobListScreenState extends State<JobListScreen> {
         borderRadius: BorderRadius.circular(12),
       ),
       child: InkWell(
-        onTap: () => _showJobPostingDetails(jobPosting),
+        onTap: () {
+          Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: (context) => JobPostingDetailScreen(jobPostingId: jobPosting.id),
+            ),
+          );
+        },
         borderRadius: BorderRadius.circular(12),
         child: Padding(
           padding: const EdgeInsets.all(16),

--- a/lib/screens/job_posting_detail_screen.dart
+++ b/lib/screens/job_posting_detail_screen.dart
@@ -1,0 +1,231 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_naver_map/flutter_naver_map.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:intl/intl.dart';
+import 'package:jejunongdi/core/models/job_posting_model.dart';
+import 'package:jejunongdi/core/services/job_posting_service.dart';
+
+class JobPostingDetailScreen extends StatefulWidget {
+  final int jobPostingId;
+
+  const JobPostingDetailScreen({
+    super.key,
+    required this.jobPostingId,
+  });
+
+  @override
+  State<JobPostingDetailScreen> createState() => _JobPostingDetailScreenState();
+}
+
+class _JobPostingDetailScreenState extends State<JobPostingDetailScreen> {
+  final JobPostingService _jobPostingService = JobPostingService.instance;
+  JobPostingResponse? _jobPosting;
+  bool _isLoading = true;
+  String? _errorMessage;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchJobPostingDetails();
+  }
+
+  Future<void> _fetchJobPostingDetails() async {
+    final result = await _jobPostingService.getJobPostingById(widget.jobPostingId);
+    if (mounted) {
+      setState(() {
+        result.onSuccess((data) {
+          _jobPosting = data;
+        });
+        result.onFailure((error) {
+          _errorMessage = error.message;
+        });
+        _isLoading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFFF8F9FA),
+      body: _isLoading
+          ? _buildLoading()
+          : _errorMessage != null
+          ? _buildError()
+          : _buildContent(),
+    );
+  }
+
+  Widget _buildLoading() {
+    return const Center(
+      child: CircularProgressIndicator(color: Color(0xFFF2711C)),
+    );
+  }
+
+  Widget _buildError() {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Icon(Icons.error_outline, color: Colors.red, size: 50),
+          const SizedBox(height: 16),
+          Text(_errorMessage ?? '데이터를 불러오는 데 실패했습니다.'),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: _fetchJobPostingDetails,
+            child: const Text('다시 시도'),
+          )
+        ],
+      ),
+    );
+  }
+
+  Widget _buildContent() {
+    final posting = _jobPosting!;
+    return CustomScrollView(
+      slivers: [
+        SliverAppBar(
+          expandedHeight: 250.0,
+          pinned: true,
+          backgroundColor: const Color(0xFFF2711C),
+          iconTheme: const IconThemeData(color: Colors.white),
+          flexibleSpace: FlexibleSpaceBar(
+            title: Text(
+              posting.farmName,
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.bold,
+                shadows: [Shadow(blurRadius: 2, color: Colors.black45)],
+              ),
+            ),
+            background: NaverMap(
+              options: NaverMapViewOptions(
+                initialCameraPosition: NCameraPosition(
+                  target: NLatLng(posting.latitude, posting.longitude),
+                  zoom: 15,
+                ),
+                mapType: NMapType.basic,
+              ),
+              onMapReady: (controller) {
+                controller.addOverlay(NMarker(
+                  id: posting.id.toString(),
+                  position: NLatLng(posting.latitude, posting.longitude),
+                ));
+              },
+            ),
+          ),
+        ),
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: const EdgeInsets.all(20.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // 제목
+                Text(
+                  posting.title,
+                  style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 12),
+
+                // 상태 및 작성일
+                Row(
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+                      decoration: BoxDecoration(
+                        color: Colors.green.withOpacity(0.1),
+                        borderRadius: BorderRadius.circular(20),
+                      ),
+                      child: Text(
+                        posting.statusName,
+                        style: TextStyle(color: Colors.green[800], fontWeight: FontWeight.bold),
+                      ),
+                    ),
+                    const Spacer(),
+                    Text(
+                      '작성일: ${DateFormat('yyyy.MM.dd').format(posting.createdAt)}',
+                      style: const TextStyle(color: Colors.grey, fontSize: 12),
+                    ),
+                  ],
+                ),
+                const Divider(height: 40),
+
+                // 상세 정보 섹션
+                _buildDetailSection('근무 정보', [
+                  _buildDetailRow(FontAwesomeIcons.calendarDays, '근무 기간', '${DateFormat('MM.dd').format(DateTime.parse(posting.workStartDate))} ~ ${DateFormat('MM.dd').format(DateTime.parse(posting.workEndDate))}'),
+                  _buildDetailRow(FontAwesomeIcons.person, '모집 인원', '${posting.recruitmentCount}명'),
+                  _buildDetailRow(FontAwesomeIcons.tractor, '주요 작물', posting.cropTypeName),
+                  _buildDetailRow(FontAwesomeIcons.hand, '주요 작업', posting.workTypeName),
+                ]),
+                const Divider(height: 40),
+
+                _buildDetailSection('급여 정보', [
+                  _buildDetailRow(FontAwesomeIcons.coins, '급여', '${NumberFormat('#,###').format(posting.wages)}원 / ${posting.wageTypeName}'),
+                ]),
+                const Divider(height: 40),
+
+                _buildDetailSection('농장 정보', [
+                  _buildDetailRow(FontAwesomeIcons.locationDot, '농장 주소', posting.address),
+                  _buildDetailRow(FontAwesomeIcons.userTie, '작성자', posting.author.nickname),
+                ]),
+                const Divider(height: 40),
+
+                // 상세 설명
+                const Text(
+                  '상세 설명',
+                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  posting.description ?? '상세 설명이 없습니다.',
+                  style: const TextStyle(fontSize: 15, height: 1.6),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildDetailSection(String title, List<Widget> children) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 16),
+        ...children,
+      ],
+    );
+  }
+
+  Widget _buildDetailRow(IconData icon, String title, String content) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12.0),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          FaIcon(icon, size: 16, color: Colors.grey[600]),
+          const SizedBox(width: 16),
+          SizedBox(
+            width: 80,
+            child: Text(
+              title,
+              style: TextStyle(fontWeight: FontWeight.w600, color: Colors.grey[800]),
+            ),
+          ),
+          Expanded(
+            child: Text(
+              content,
+              style: const TextStyle(fontSize: 15),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #24 

## 📝작업 내용

> 
- [X] `JobPostingDetailScreen`을 추가하여 공고의 상세 정보를 표시하는 새로운 페이지를 구현했습니다.
- [X] `JobPostingService`에 `getJobPostingById` 메소드를 추가하여 ID로 특정 공고 정보를 가져오는 기능을 구현했습니다.
- [X] 홈 화면과 공고 목록 화면에서 공고 항목을 탭했을 때, 기존의 하단 시트 대신 새로운 공고 상세 페이지로 이동하도록 탐색 로직을 수정했습니다.

## 💬리뷰 요구사항

> 확인 후 merge 부탁 드립니다!!