### PR TITLE
feat(chat): 실시간 채팅 기능 구현 (WebSocket/STOMP)

### DIFF
--- a/.dart_tool/package_graph.json
+++ b/.dart_tool/package_graph.json
@@ -28,7 +28,9 @@
         "retrofit",
         "retrofit_generator",
         "shared_preferences",
-        "url_launcher"
+        "stomp_dart_client",
+        "url_launcher",
+        "web_socket_channel"
       ],
       "devDependencies": [
         "build_runner",
@@ -145,6 +147,22 @@
         "test_api",
         "vector_math",
         "vm_service"
+      ]
+    },
+    {
+      "name": "web_socket_channel",
+      "version": "2.4.0",
+      "dependencies": [
+        "async",
+        "crypto",
+        "stream_channel"
+      ]
+    },
+    {
+      "name": "stomp_dart_client",
+      "version": "1.0.3",
+      "dependencies": [
+        "web_socket_channel"
       ]
     },
     {
@@ -413,17 +431,6 @@
       "name": "args",
       "version": "2.7.0",
       "dependencies": []
-    },
-    {
-      "name": "web_socket_channel",
-      "version": "3.0.3",
-      "dependencies": [
-        "async",
-        "crypto",
-        "stream_channel",
-        "web",
-        "web_socket"
-      ]
     },
     {
       "name": "web",
@@ -1272,13 +1279,6 @@
         "collection",
         "meta",
         "petitparser"
-      ]
-    },
-    {
-      "name": "web_socket",
-      "version": "1.0.1",
-      "dependencies": [
-        "web"
       ]
     },
     {

--- a/lib/core/models/chat_models.dart
+++ b/lib/core/models/chat_models.dart
@@ -286,24 +286,28 @@ class ChatRoomView {
 // 메시지 DTO (API 명세의 MessageDto)
 @JsonSerializable()
 class MessageDto {
-  final String messageId;
+  final String id;
   final String roomId;
-  final UserResponse sender;
+  final UserResponse senderId;
+  final String email;
   final String content;
   final String? fileUrl;
   final String messageType;
-  final DateTime sentAt;
+  final DateTime createdAt;
   final bool isRead;
+  final String? senderProfileImage;
 
   MessageDto({
-    required this.messageId,
+    required this.id,
     required this.roomId,
-    required this.sender,
+    required this.senderId,
+    required this.email,
     required this.content,
     this.fileUrl,
     required this.messageType,
-    required this.sentAt,
+    required this.createdAt,
     this.isRead = false,
+    this.senderProfileImage,
   });
 
   factory MessageDto.fromJson(Map<String, dynamic> json) =>

--- a/lib/core/models/chat_models.dart
+++ b/lib/core/models/chat_models.dart
@@ -124,19 +124,47 @@ class UnreadCountResponse {
 class WebSocketConnectionInfo {
   final String endpoint;
   final String protocol;
-  final String? authenticationMethod;
-  final Map<String, dynamic>? additionalParams;
+  final String? authentication;
+  final String? sendDestination;
+  final String? subscribePattern;
+  final bool? sockJsEnabled;
 
   WebSocketConnectionInfo({
     required this.endpoint,
     required this.protocol,
-    this.authenticationMethod,
-    this.additionalParams,
+    this.authentication,
+    this.sendDestination,
+    this.subscribePattern,
+    this.sockJsEnabled,
   });
 
   factory WebSocketConnectionInfo.fromJson(Map<String, dynamic> json) =>
       _$WebSocketConnectionInfoFromJson(json);
   Map<String, dynamic> toJson() => _$WebSocketConnectionInfoToJson(this);
+}
+
+// 1:1 채팅방 조회/생성 API 응답 모델 
+@JsonSerializable()
+class OneToOneChatRoomDto {
+  final String roomId;
+  final int user1Id;
+  final int user2Id;
+  final DateTime createdAt;
+  final String otherUserNickname;
+  final String? otherUserProfileImage;
+
+  OneToOneChatRoomDto({
+    required this.roomId,
+    required this.user1Id,
+    required this.user2Id,
+    required this.createdAt,
+    required this.otherUserNickname,
+    this.otherUserProfileImage,
+  });
+
+  factory OneToOneChatRoomDto.fromJson(Map<String, dynamic> json) =>
+      _$OneToOneChatRoomDtoFromJson(json);
+  Map<String, dynamic> toJson() => _$OneToOneChatRoomDtoToJson(this);
 }
 
 // 채팅방 상세 정보 (API 명세의 ChatRoomDto)
@@ -170,7 +198,6 @@ class ChatRoomDto {
 }
 
 // 채팅방 뷰 모델 (API 명세의 ChatRoomView)
-@JsonSerializable()
 class ChatRoomView {
   final String roomId;
   final String? roomName;
@@ -187,12 +214,73 @@ class ChatRoomView {
     this.lastMessage,
     this.lastMessageTime,
     this.unreadCount = 0,
-    required this.chatType,
+    this.chatType = 'GENERAL', // 기본값 제공
   });
 
-  factory ChatRoomView.fromJson(Map<String, dynamic> json) =>
-      _$ChatRoomViewFromJson(json);
-  Map<String, dynamic> toJson() => _$ChatRoomViewToJson(this);
+  factory ChatRoomView.fromJson(Map<String, dynamic> json) {
+    try {
+      print('🔍 ChatRoomView 파싱 중: $json');
+      
+      // roomId 검증
+      final roomId = json['roomId'] as String?;
+      if (roomId == null || roomId.isEmpty) {
+        throw Exception('roomId가 null이거나 비어있습니다');
+      }
+      
+      // otherUser 파싱
+      UserResponse? otherUser;
+      if (json['otherUser'] != null) {
+        try {
+          if (json['otherUser'] is Map<String, dynamic>) {
+            otherUser = UserResponse.fromJson(json['otherUser'] as Map<String, dynamic>);
+          }
+        } catch (e) {
+          print('⚠️ otherUser 파싱 실패: $e');
+          otherUser = null;
+        }
+      }
+      
+      // lastMessageTime 파싱
+      DateTime? lastMessageTime;
+      if (json['lastMessageTime'] != null) {
+        try {
+          if (json['lastMessageTime'] is String) {
+            lastMessageTime = DateTime.parse(json['lastMessageTime'] as String);
+          }
+        } catch (e) {
+          print('⚠️ lastMessageTime 파싱 실패: $e');
+          lastMessageTime = null;
+        }
+      }
+      
+      final result = ChatRoomView(
+        roomId: roomId,
+        roomName: json['roomName'] as String?,
+        otherUser: otherUser,
+        lastMessage: json['lastMessage'] as String?,
+        lastMessageTime: lastMessageTime,
+        unreadCount: (json['unreadCount'] as num?)?.toInt() ?? 0,
+        chatType: json['chatType'] as String? ?? 'GENERAL',
+      );
+      
+      print('✅ ChatRoomView 파싱 성공: roomId=$roomId, chatType=${result.chatType}');
+      return result;
+    } catch (e) {
+      print('❌ ChatRoomView 파싱 오류: $e');
+      print('📊 원본 데이터: $json');
+      rethrow;
+    }
+  }
+  
+  Map<String, dynamic> toJson() => {
+    'roomId': roomId,
+    'roomName': roomName,
+    'otherUser': otherUser?.toJson(),
+    'lastMessage': lastMessage,
+    'lastMessageTime': lastMessageTime?.toIso8601String(),
+    'unreadCount': unreadCount,
+    'chatType': chatType,
+  };
 }
 
 // 메시지 DTO (API 명세의 MessageDto)

--- a/lib/core/models/chat_models.g.dart
+++ b/lib/core/models/chat_models.g.dart
@@ -158,50 +158,29 @@ Map<String, dynamic> _$ChatRoomDtoToJson(ChatRoomDto instance) =>
       'updatedAt': instance.updatedAt?.toIso8601String(),
     };
 
-ChatRoomView _$ChatRoomViewFromJson(Map<String, dynamic> json) => ChatRoomView(
-  roomId: json['roomId'] as String,
-  roomName: json['roomName'] as String?,
-  otherUser: json['otherUser'] == null
-      ? null
-      : UserResponse.fromJson(json['otherUser'] as Map<String, dynamic>),
-  lastMessage: json['lastMessage'] as String?,
-  lastMessageTime: json['lastMessageTime'] == null
-      ? null
-      : DateTime.parse(json['lastMessageTime'] as String),
-  unreadCount: (json['unreadCount'] as num?)?.toInt() ?? 0,
-  chatType: json['chatType'] as String? ?? 'GENERAL',
-);
-
-Map<String, dynamic> _$ChatRoomViewToJson(ChatRoomView instance) =>
-    <String, dynamic>{
-      'roomId': instance.roomId,
-      'roomName': instance.roomName,
-      'otherUser': instance.otherUser,
-      'lastMessage': instance.lastMessage,
-      'lastMessageTime': instance.lastMessageTime?.toIso8601String(),
-      'unreadCount': instance.unreadCount,
-      'chatType': instance.chatType,
-    };
-
 MessageDto _$MessageDtoFromJson(Map<String, dynamic> json) => MessageDto(
-  messageId: json['messageId'] as String,
+  id: json['id'] as String,
   roomId: json['roomId'] as String,
-  sender: UserResponse.fromJson(json['sender'] as Map<String, dynamic>),
+  senderId: UserResponse.fromJson(json['senderId'] as Map<String, dynamic>),
+  email: json['email'] as String,
   content: json['content'] as String,
   fileUrl: json['fileUrl'] as String?,
   messageType: json['messageType'] as String,
-  sentAt: DateTime.parse(json['sentAt'] as String),
+  createdAt: DateTime.parse(json['createdAt'] as String),
   isRead: json['isRead'] as bool? ?? false,
+  senderProfileImage: json['senderProfileImage'] as String?,
 );
 
 Map<String, dynamic> _$MessageDtoToJson(MessageDto instance) =>
     <String, dynamic>{
-      'messageId': instance.messageId,
+      'id': instance.id,
       'roomId': instance.roomId,
-      'sender': instance.sender,
+      'senderId': instance.senderId,
+      'email': instance.email,
       'content': instance.content,
       'fileUrl': instance.fileUrl,
       'messageType': instance.messageType,
-      'sentAt': instance.sentAt.toIso8601String(),
+      'createdAt': instance.createdAt.toIso8601String(),
       'isRead': instance.isRead,
+      'senderProfileImage': instance.senderProfileImage,
     };

--- a/lib/core/models/chat_models.g.dart
+++ b/lib/core/models/chat_models.g.dart
@@ -89,8 +89,10 @@ WebSocketConnectionInfo _$WebSocketConnectionInfoFromJson(
 ) => WebSocketConnectionInfo(
   endpoint: json['endpoint'] as String,
   protocol: json['protocol'] as String,
-  authenticationMethod: json['authenticationMethod'] as String?,
-  additionalParams: json['additionalParams'] as Map<String, dynamic>?,
+  authentication: json['authentication'] as String?,
+  sendDestination: json['sendDestination'] as String?,
+  subscribePattern: json['subscribePattern'] as String?,
+  sockJsEnabled: json['sockJsEnabled'] as bool?,
 );
 
 Map<String, dynamic> _$WebSocketConnectionInfoToJson(
@@ -98,8 +100,31 @@ Map<String, dynamic> _$WebSocketConnectionInfoToJson(
 ) => <String, dynamic>{
   'endpoint': instance.endpoint,
   'protocol': instance.protocol,
-  'authenticationMethod': instance.authenticationMethod,
-  'additionalParams': instance.additionalParams,
+  'authentication': instance.authentication,
+  'sendDestination': instance.sendDestination,
+  'subscribePattern': instance.subscribePattern,
+  'sockJsEnabled': instance.sockJsEnabled,
+};
+
+OneToOneChatRoomDto _$OneToOneChatRoomDtoFromJson(Map<String, dynamic> json) =>
+    OneToOneChatRoomDto(
+      roomId: json['roomId'] as String,
+      user1Id: (json['user1Id'] as num).toInt(),
+      user2Id: (json['user2Id'] as num).toInt(),
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      otherUserNickname: json['otherUserNickname'] as String,
+      otherUserProfileImage: json['otherUserProfileImage'] as String?,
+    );
+
+Map<String, dynamic> _$OneToOneChatRoomDtoToJson(
+  OneToOneChatRoomDto instance,
+) => <String, dynamic>{
+  'roomId': instance.roomId,
+  'user1Id': instance.user1Id,
+  'user2Id': instance.user2Id,
+  'createdAt': instance.createdAt.toIso8601String(),
+  'otherUserNickname': instance.otherUserNickname,
+  'otherUserProfileImage': instance.otherUserProfileImage,
 };
 
 ChatRoomDto _$ChatRoomDtoFromJson(Map<String, dynamic> json) => ChatRoomDto(
@@ -144,7 +169,7 @@ ChatRoomView _$ChatRoomViewFromJson(Map<String, dynamic> json) => ChatRoomView(
       ? null
       : DateTime.parse(json['lastMessageTime'] as String),
   unreadCount: (json['unreadCount'] as num?)?.toInt() ?? 0,
-  chatType: json['chatType'] as String,
+  chatType: json['chatType'] as String? ?? 'GENERAL',
 );
 
 Map<String, dynamic> _$ChatRoomViewToJson(ChatRoomView instance) =>

--- a/lib/core/network/api_client.dart
+++ b/lib/core/network/api_client.dart
@@ -255,6 +255,16 @@ class ApiClient {
     }
   }
   
+  // 토큰 가져오기
+  Future<String?> getToken() async {
+    try {
+      return await _secureStorage.read(key: 'access_token');
+    } catch (e) {
+      Logger.error('Failed to get token', error: e);
+      return null;
+    }
+  }
+  
   // Dio 인스턴스 직접 접근 (필요한 경우)
   Dio get dio => _dio;
 }

--- a/lib/core/services/place_search_service_new.dart
+++ b/lib/core/services/place_search_service_new.dart
@@ -1,4 +1,3 @@
-import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:jejunongdi/core/models/place_search_models.dart';
 

--- a/lib/core/services/websocket_service.dart
+++ b/lib/core/services/websocket_service.dart
@@ -1,0 +1,313 @@
+// lib/core/services/websocket_service.dart
+
+import 'dart:async';
+import 'dart:convert';
+import 'package:jejunongdi/core/models/chat_models.dart';
+import 'package:jejunongdi/core/network/api_client.dart';
+import 'package:jejunongdi/core/utils/logger.dart';
+import 'package:jejunongdi/core/services/chat_service.dart';
+import 'package:jejunongdi/core/config/environment.dart';
+import 'package:stomp_dart_client/stomp_dart_client.dart';
+
+class WebSocketService {
+  static WebSocketService? _instance;
+  StompClient? _stompClient;
+  bool _isConnected = false;
+  final StreamController<MessageDto> _messageController = StreamController<MessageDto>.broadcast();
+  Timer? _reconnectTimer;
+  int _reconnectAttempts = 0;
+  static const int _maxReconnectAttempts = 5;
+  
+  String? _authToken;
+  WebSocketConnectionInfo? _wsInfo;
+  StompUnsubscribe? _currentRoomSubscription;
+
+  static WebSocketService get instance {
+    _instance ??= WebSocketService._internal();
+    return _instance!;
+  }
+
+  WebSocketService._internal();
+
+  Stream<MessageDto> get messageStream => _messageController.stream;
+  bool get isConnected => _isConnected;
+
+  /// STOMP WebSocket 연결 초기화
+  Future<bool> connect() async {
+    try {
+      print('🔌 STOMP WebSocket 연결 시도 시작');
+      Logger.info('STOMP WebSocket 연결 시도');
+      
+      // WebSocket 연결 정보 조회
+      print('📡 WebSocket 연결 정보 조회 중...');
+      final wsInfoResult = await ChatService.instance.getWebSocketInfo();
+      print('📡 WebSocket 연결 정보 조회 결과: success=${wsInfoResult.isSuccess}, data=${wsInfoResult.data != null}');
+      
+      if (!wsInfoResult.isSuccess || wsInfoResult.data == null) {
+        print('❌ WebSocket 연결 정보를 가져올 수 없습니다');
+        Logger.error('WebSocket 연결 정보를 가져올 수 없습니다.');
+        return false;
+      }
+
+      _wsInfo = wsInfoResult.data!;
+      print('✅ WebSocket 연결 정보 저장 완료: endpoint=${_wsInfo!.endpoint}');
+      
+      // 인증 토큰 가져오기
+      print('🔑 인증 토큰 조회 중...');
+      _authToken = await ApiClient.instance.getToken();
+      if (_authToken == null) {
+        print('❌ 인증 토큰이 없습니다');
+        Logger.error('인증 토큰이 없습니다.');
+        return false;
+      }
+      print('✅ 인증 토큰 조회 완료');
+
+      // WebSocket URL 생성
+      final baseUrl = EnvironmentConfig.apiBaseUrl;
+
+      final Map<String, String> connectHeaders = {
+        'Authorization': 'Bearer $_authToken',
+        'Accept-Version': '1.0,1.1,2.0',
+        'Heart-Beat': _wsInfo!.sockJsEnabled == true ? '20000,20000' : '10000,10000',
+      };
+
+      final Map<String, String> wsHeaders = {
+        'Authorization': 'Bearer $_authToken',
+      };
+
+      if (_wsInfo!.sockJsEnabled != true) {
+        wsHeaders['Sec-WebSocket-Protocol'] = 'v10.stomp, v11.stomp, v12.stomp';
+      }
+
+      final StompConfig config;
+      if (_wsInfo!.sockJsEnabled == true) {
+        final sockJsUrl = baseUrl + (_wsInfo?.endpoint ?? '');
+        Logger.info('SockJS URL: $sockJsUrl');
+        config = StompConfig.sockJS(
+          url: sockJsUrl,
+          onConnect: _onConnected,
+          onWebSocketError: (error) => Logger.error('WebSocket 오류: $error'),
+          onStompError: (error) => Logger.error('STOMP 오류: $error'),
+          onDisconnect: _onDisconnected,
+          stompConnectHeaders: connectHeaders,
+          webSocketConnectHeaders: wsHeaders,
+        );
+      } else {
+        final wsUrl = baseUrl.replaceFirst(RegExp(r'^http'), 'ws') + (_wsInfo?.endpoint ?? '');
+        Logger.info('STOMP WebSocket 연결 URL: $wsUrl');
+        config = StompConfig(
+          url: wsUrl,
+          onConnect: _onConnected,
+          onWebSocketError: (error) => Logger.error('WebSocket 오류: $error'),
+          onStompError: (error) => Logger.error('STOMP 오류: $error'),
+          onDisconnect: _onDisconnected,
+          stompConnectHeaders: connectHeaders,
+          webSocketConnectHeaders: wsHeaders,
+        );
+      }
+
+      print('🔗 StompClient 생성 및 활성화 시작...');
+      _stompClient = StompClient(config: config);
+
+      // 연결 완료를 기다리기 위한 Completer
+      final completer = Completer<bool>();
+      late StreamSubscription subscription;
+      
+      // 연결 상태 변경을 감지하기 위한 타이머
+      Timer? timeoutTimer;
+      
+      void checkConnection() {
+        if (_isConnected) {
+          print('✅ WebSocket 연결 완료 감지');
+          completer.complete(true);
+          subscription.cancel();
+          timeoutTimer?.cancel();
+        }
+      }
+      
+      // 주기적으로 연결 상태 확인 (100ms마다)
+      subscription = Stream.periodic(const Duration(milliseconds: 100))
+          .listen((_) => checkConnection());
+      
+      // 10초 타임아웃
+      timeoutTimer = Timer(const Duration(seconds: 10), () {
+        if (!completer.isCompleted) {
+          print('❌ WebSocket 연결 타임아웃 (10초)');
+          completer.complete(false);
+          subscription.cancel();
+        }
+      });
+      
+      // 연결 시작
+      print('🚀 WebSocket 연결 활성화...');
+      _stompClient!.activate();
+      
+      // 연결 완료 대기
+      return await completer.future;
+    } catch (e) {
+      Logger.error('STOMP WebSocket 연결 실패', error: e);
+      _isConnected = false;
+      _scheduleReconnect();
+      return false;
+    }
+  }
+
+  /// STOMP 연결 성공 콜백
+  void _onConnected(StompFrame frame) {
+    Logger.info('STOMP WebSocket 연결 성공');
+    _isConnected = true;
+    _reconnectAttempts = 0;
+    _reconnectTimer?.cancel();
+  }
+
+  /// STOMP 연결 종료 콜백
+  void _onDisconnected(StompFrame frame) {
+    Logger.info('STOMP WebSocket 연결 종료');
+    _isConnected = false;
+    _scheduleReconnect();
+  }
+
+  /// 채팅방 구독 및 입장
+  Future<bool> joinRoom(String roomId) async {
+    print('🔄 joinRoom 시작: roomId=$roomId');
+    print('🔄 현재 연결 상태: _isConnected=$_isConnected, _stompClient=${_stompClient != null}, _wsInfo=${_wsInfo != null}');
+    
+    if (!_isConnected || _stompClient == null || _wsInfo == null) {
+      print('❌ WebSocket 연결 상태 불량');
+      Logger.error('STOMP WebSocket이 연결되어 있지 않습니다.');
+      return false;
+    }
+
+    try {
+      // 이전 구독 해제
+      if (_currentRoomSubscription != null) {
+        print('🔄 기존 구독 해제 중...');
+        _currentRoomSubscription!();
+      }
+
+      // 새 채팅방 구독
+      final subscribeDestination = _wsInfo!.subscribePattern?.replaceAll('{roomId}', roomId) ?? '/topic/chat/room/$roomId';
+      print('🔔 채팅방 구독 시도: $subscribeDestination');
+      Logger.info('채팅방 구독: $subscribeDestination');
+      
+      _currentRoomSubscription = _stompClient!.subscribe(
+        destination: subscribeDestination,
+        callback: (frame) {
+          try {
+            print('📨 STOMP 원시 메시지 수신: ${frame.body}');
+            Logger.info('STOMP 메시지 수신: ${frame.body}');
+            if (frame.body != null) {
+              final messageData = json.decode(frame.body!);
+              final message = MessageDto.fromJson(messageData);
+              print('📨 메시지 파싱 성공, 스트림에 추가: ${message.messageId}');
+              _messageController.add(message);
+            }
+          } catch (e) {
+            print('❌ STOMP 메시지 파싱 실패: $e');
+            Logger.error('STOMP 메시지 파싱 실패', error: e);
+          }
+        },
+      );
+
+      print('✅ 채팅방 구독 완료: $roomId');
+      Logger.info('채팅방 입장 성공: $roomId');
+      return true;
+    } catch (e) {
+      print('❌ 채팅방 입장 실패: $e');
+      Logger.error('채팅방 입장 실패', error: e);
+      return false;
+    }
+  }
+
+  /// 채팅방 퇴장
+  Future<bool> leaveRoom(String roomId) async {
+    if (_currentRoomSubscription != null && _stompClient != null) {
+      try {
+        _currentRoomSubscription!();
+        _currentRoomSubscription = null;
+        Logger.info('채팅방 퇴장: $roomId');
+        return true;
+      } catch (e) {
+        Logger.error('채팅방 퇴장 실패', error: e);
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// 메시지 전송
+  Future<bool> sendMessage({
+    required String roomId,
+    required String content,
+    String messageType = 'TEXT',
+  }) async {
+    print('🚀 === WebSocket 메시지 전송 시작 ===');
+    print('🔌 WebSocket 연결 상태: $_isConnected');
+    print('📡 StompClient 상태: ${_stompClient != null}');
+    print('⚙️ WebSocket 정보: ${_wsInfo != null}');
+    
+    if (!_isConnected || _stompClient == null || _wsInfo == null) {
+      print('❌ WebSocket 전송 조건 미충족');
+      Logger.error('STOMP WebSocket이 연결되어 있지 않습니다.');
+      return false;
+    }
+
+    try {
+      final messageData = {
+        'roomId': roomId,
+        'content': content,
+        'messageType': messageType,
+      };
+
+      final destination = _wsInfo!.sendDestination ?? '/app/chat.sendPrivateMessage';
+      print('🎯 전송 목적지: $destination');
+      print('📦 전송 데이터: $messageData');
+
+      _stompClient!.send(
+        destination: destination,
+        body: json.encode(messageData),
+      );
+
+      print('✅ STOMP 메시지 전송 완료');
+      Logger.info('STOMP 메시지 전송: $messageData');
+      return true;
+    } catch (e) {
+      print('❌ STOMP 메시지 전송 실패: $e');
+      Logger.error('STOMP 메시지 전송 실패', error: e);
+      return false;
+    }
+  }
+
+  /// 재연결 스케줄링
+  void _scheduleReconnect() {
+    if (_reconnectAttempts >= _maxReconnectAttempts) {
+      Logger.error('최대 재연결 시도 횟수에 도달했습니다.');
+      return;
+    }
+
+    _reconnectTimer?.cancel();
+    final delay = Duration(seconds: (1 << _reconnectAttempts).clamp(1, 30));
+    
+    _reconnectTimer = Timer(delay, () {
+      _reconnectAttempts++;
+      Logger.info('STOMP WebSocket 재연결 시도 $_reconnectAttempts/$_maxReconnectAttempts');
+      connect();
+    });
+  }
+
+  /// 연결 종료
+  void disconnect() {
+    Logger.info('STOMP WebSocket 연결 종료');
+    _isConnected = false;
+    _reconnectTimer?.cancel();
+    _currentRoomSubscription = null;
+    _stompClient?.deactivate();
+    _stompClient = null;
+  }
+
+  /// 리소스 정리
+  void dispose() {
+    disconnect();
+    _messageController.close();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:jejunongdi/screens/main_navigation.dart';
 import 'package:jejunongdi/screens/login_screen.dart';
 import 'package:jejunongdi/screens/signup_screen.dart';
 import 'package:jejunongdi/core/config/environment.dart';
+import 'package:jejunongdi/core/services/websocket_service.dart';
 import 'package:flutter_naver_map/flutter_naver_map.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:intl/date_symbol_data_local.dart';
@@ -27,6 +28,10 @@ Future<void> main() async {
   // Redux Store 초기화
   redux_store.initializeStore();
   print('✅ Redux Store 초기화 완료');
+
+  // WebSocketService에 Redux Store 설정
+  WebSocketService.instance.setStore(redux_store.store);
+  print('✅ WebSocketService Redux Store 연동 완료');
 
   // 모바일 환경에서만 네이버 지도 API 키 초기화
   if (!kIsWeb) {

--- a/lib/redux/chat/chat_actions.dart
+++ b/lib/redux/chat/chat_actions.dart
@@ -85,21 +85,20 @@ class DeleteChatRoomSuccessAction {
   DeleteChatRoomSuccessAction(this.roomId);
 }
 
-// --- 더미 데이터 생성 관련 액션 ---
-class CreateDummyChatRoomsAction {}
+// --- WebSocket 실시간 연결 관련 액션 ---
+class ConnectWebSocketAction {}
 
-class CreateDummyChatRoomsSuccessAction {
-  final List<ChatRoomView> dummyChatRooms;
-  CreateDummyChatRoomsSuccessAction(this.dummyChatRooms);
-}
+class ConnectWebSocketSuccessAction {}
 
-class CreateDummyMessagesAction {
+class DisconnectWebSocketAction {}
+
+class JoinChatRoomAction {
   final String roomId;
-  CreateDummyMessagesAction(this.roomId);
+  JoinChatRoomAction(this.roomId);
 }
 
-class CreateDummyMessagesSuccessAction {
+class LeaveChatRoomAction {
   final String roomId;
-  final List<MessageDto> dummyMessages;
-  CreateDummyMessagesSuccessAction(this.roomId, this.dummyMessages);
+  LeaveChatRoomAction(this.roomId);
 }
+

--- a/lib/redux/chat/chat_middleware.dart
+++ b/lib/redux/chat/chat_middleware.dart
@@ -111,7 +111,7 @@ _sendMessage(ChatService service, WebSocketService webSocketService) {
       );
       
       result.onSuccess((message) {
-        print('✅ HTTP API 메시지 전송 성공: ${message.messageId}');
+        print('✅ HTTP API 메시지 전송 성공: ${message.id}');
         store.dispatch(ReceiveMessageAction(message));
         store.dispatch(SetChatLoadingAction(false));
       }).onFailure((error) {
@@ -174,7 +174,7 @@ _connectWebSocket(WebSocketService webSocketService) {
       store.dispatch(ConnectWebSocketSuccessAction());
       // WebSocket 메시지 스트림 리스닝 시작 (중복 방지)
       _webSocketStreamSubscription = webSocketService.messageStream.listen((message) {
-        print('📨 WebSocket 메시지 수신: roomId=${message.roomId}, messageId=${message.messageId}, content=${message.content}');
+        print('📨 WebSocket 메시지 수신: roomId=${message.roomId}, messageId=${message.id}, content=${message.content}');
         store.dispatch(ReceiveMessageAction(message));
       });
       print('👂 WebSocket 메시지 스트림 리스너 등록 완료');

--- a/lib/redux/chat/chat_reducer.dart
+++ b/lib/redux/chat/chat_reducer.dart
@@ -46,12 +46,12 @@ ChatState _loadChatMessagesSuccess(ChatState state, LoadChatMessagesSuccessActio
   final existingMessages = newMessages[action.roomId] ?? [];
 
   // 중복을 제외한 새 메시지만 필터링
-  final existingMessageIds = existingMessages.map((m) => m.messageId).toSet();
-  final uniqueNewMessages = action.messages.where((m) => !existingMessageIds.contains(m.messageId));
+  final existingMessageIds = existingMessages.map((m) => m.id).toSet();
+  final uniqueNewMessages = action.messages.where((m) => !existingMessageIds.contains(m.id));
 
   // 기존 메시지와 새로운 메시지를 합치고 시간 역순으로 정렬 (최신 메시지가 위로)
   final allMessages = [...existingMessages, ...uniqueNewMessages];
-  allMessages.sort((a, b) => b.sentAt.compareTo(a.sentAt));
+  allMessages.sort((a, b) => b.createdAt.compareTo(a.createdAt));
 
   newMessages[action.roomId] = allMessages;
 
@@ -70,7 +70,7 @@ ChatState _loadChatMessagesSuccess(ChatState state, LoadChatMessagesSuccessActio
 }
 
 ChatState _receiveMessage(ChatState state, ReceiveMessageAction action) {
-  print('📥 ReceiveMessageAction 처리: roomId=${action.message.roomId}, messageId=${action.message.messageId}, content=${action.message.content}');
+  print('📥 ReceiveMessageAction 처리: roomId=${action.message.roomId}, messageId=${action.message.id}, content=${action.message.content}');
   
   final newMessages = Map<String, List<MessageDto>>.from(state.messages);
   final roomMessages = newMessages[action.message.roomId] ?? [];
@@ -79,16 +79,16 @@ ChatState _receiveMessage(ChatState state, ReceiveMessageAction action) {
 
   // 중복 방지: messageId와 content+sentAt 기반 중복 검사
   final messageExists = roomMessages.any((m) => 
-    m.messageId == action.message.messageId ||
+    m.id == action.message.id ||
     (m.content == action.message.content && 
-     m.sender.id == action.message.sender.id &&
-     m.sentAt.difference(action.message.sentAt).abs().inSeconds < 2) // 2초 이내 동일 메시지는 중복으로 간주
+     m.senderId.id == action.message.senderId.id &&
+     m.createdAt.difference(action.message.createdAt).abs().inSeconds < 2) // 2초 이내 동일 메시지는 중복으로 간주
   );
   
   if (!messageExists) {
     print('✅ 새 메시지 추가 중...');
     final updatedMessages = [action.message, ...roomMessages];
-    updatedMessages.sort((a, b) => b.sentAt.compareTo(a.sentAt));
+    updatedMessages.sort((a, b) => b.createdAt.compareTo(a.createdAt));
     newMessages[action.message.roomId] = updatedMessages;
     print('📊 업데이트 후 메시지 개수: ${updatedMessages.length}');
   } else {

--- a/lib/screens/chat_list_screen.dart
+++ b/lib/screens/chat_list_screen.dart
@@ -62,42 +62,11 @@ class _ChatListScreenState extends State<ChatListScreen> {
                           ],
                         ),
                         child: IconButton(
-                          icon: const Icon(Icons.data_usage),
-                          tooltip: '더미 채팅방 생성',
-                          color: Colors.green,
-                          onPressed: () {
-                            final store = StoreProvider.of<AppState>(context, listen: false);
-                            store.dispatch(CreateDummyChatRoomsAction());
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              const SnackBar(
-                                content: Text('더미 채팅방을 생성했습니다!'),
-                                backgroundColor: Colors.green,
-                              ),
-                            );
-                          },
-                        ),
-                      ),
-                      const SizedBox(width: 8),
-                      Container(
-                        decoration: BoxDecoration(
-                          color: Colors.white,
-                          borderRadius: BorderRadius.circular(12),
-                          boxShadow: [
-                            BoxShadow(
-                              color: Colors.black.withOpacity(0.1),
-                              blurRadius: 8,
-                              offset: const Offset(0, 2),
-                            ),
-                          ],
-                        ),
-                        child: IconButton(
                           icon: const Icon(Icons.add_comment_outlined),
                           tooltip: '새 대화',
                           color: const Color(0xFFF2711C),
                           onPressed: () {
-                            final store = StoreProvider.of<AppState>(context, listen: false);
-                            // 새로운 API 사용: 1:1 채팅방 생성 (예시 이메일)
-                            store.dispatch(GetOrCreateOneToOneRoomAction("example@test.com"));
+                            _showCreateChatDialog(context);
                           },
                         ),
                       ),
@@ -193,68 +162,114 @@ class _ChatRoomTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ListTile(
-      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-      leading: CircleAvatar(
-        radius: 28,
-        backgroundColor: const Color(0xFFF2711C).withOpacity(0.1),
-        backgroundImage: chatRoom.otherUser?.profileImageUrl != null
-            ? NetworkImage(chatRoom.otherUser!.profileImageUrl!)
-            : null,
-        child: chatRoom.otherUser?.profileImageUrl == null
-            ? const Icon(Icons.group, color: Color(0xFFF2711C))
-            : null,
-      ),
-      title: Text(
-        chatRoom.roomName ?? chatRoom.otherUser?.name ?? '이름 없는 채팅방',
-        style: const TextStyle(fontWeight: FontWeight.bold),
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-      ),
-      subtitle: Text(
-        chatRoom.lastMessage ?? '대화를 시작해보세요.',
-        style: TextStyle(
-          color: Colors.grey[600],
-          fontWeight: chatRoom.unreadCount > 0 ? FontWeight.bold : FontWeight.normal,
+    return Dismissible(
+      key: Key(chatRoom.roomId),
+      direction: DismissDirection.endToStart,
+      background: Container(
+        alignment: Alignment.centerRight,
+        padding: const EdgeInsets.only(right: 20),
+        color: Colors.red,
+        child: const Icon(
+          Icons.delete,
+          color: Colors.white,
+          size: 28,
         ),
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
       ),
-      trailing: Column(
-        crossAxisAlignment: CrossAxisAlignment.end,
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Text(
-            _formatDateTime(chatRoom.lastMessageTime),
-            style: TextStyle(color: Colors.grey[500], fontSize: 12),
-          ),
-          const SizedBox(height: 6),
-          if (chatRoom.unreadCount > 0)
-            Container(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-              decoration: BoxDecoration(
-                color: const Color(0xFFF2711C),
-                borderRadius: BorderRadius.circular(12),
-              ),
-              child: Text(
-                '${chatRoom.unreadCount}',
-                style: const TextStyle(color: Colors.white, fontSize: 12),
-              ),
-            )
-          else
-            const SizedBox(height: 20),
-        ],
-      ),
-      onTap: () {
-        Navigator.of(context).push(
-          MaterialPageRoute(
-            builder: (context) => ChatRoomScreen(
-              roomId: chatRoom.roomId,
-              roomName: chatRoom.roomName ?? '이름 없는 채팅방',
-            ),
+      confirmDismiss: (direction) async {
+        return await showDialog(
+          context: context,
+          builder: (BuildContext context) {
+            return AlertDialog(
+              title: const Text('채팅방 삭제'),
+              content: const Text('이 채팅방을 삭제하시겠습니까?'),
+              actions: <Widget>[
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(false),
+                  child: const Text('취소'),
+                ),
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(true),
+                  style: TextButton.styleFrom(foregroundColor: Colors.red),
+                  child: const Text('삭제'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+      onDismissed: (direction) {
+        StoreProvider.of<AppState>(context, listen: false)
+            .dispatch(DeleteChatRoomAction(chatRoom.roomId));
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('${chatRoom.roomName ?? "채팅방"}이 삭제되었습니다.'),
+            backgroundColor: Colors.red,
           ),
         );
       },
+      child: ListTile(
+        contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+        leading: CircleAvatar(
+          radius: 28,
+          backgroundColor: const Color(0xFFF2711C).withOpacity(0.1),
+          backgroundImage: chatRoom.otherUser?.profileImageUrl != null
+              ? NetworkImage(chatRoom.otherUser!.profileImageUrl!)
+              : null,
+          child: chatRoom.otherUser?.profileImageUrl == null
+              ? const Icon(Icons.group, color: Color(0xFFF2711C))
+              : null,
+        ),
+        title: Text(
+          chatRoom.roomName ?? chatRoom.otherUser?.name ?? '이름 없는 채팅방',
+          style: const TextStyle(fontWeight: FontWeight.bold),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        subtitle: Text(
+          chatRoom.lastMessage ?? '대화를 시작해보세요.',
+          style: TextStyle(
+            color: Colors.grey[600],
+            fontWeight: chatRoom.unreadCount > 0 ? FontWeight.bold : FontWeight.normal,
+          ),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        trailing: Column(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              _formatDateTime(chatRoom.lastMessageTime),
+              style: TextStyle(color: Colors.grey[500], fontSize: 12),
+            ),
+            const SizedBox(height: 6),
+            if (chatRoom.unreadCount > 0)
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                decoration: BoxDecoration(
+                  color: const Color(0xFFF2711C),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Text(
+                  '${chatRoom.unreadCount}',
+                  style: const TextStyle(color: Colors.white, fontSize: 12),
+                ),
+              )
+            else
+              const SizedBox(height: 20),
+          ],
+        ),
+        onTap: () {
+          Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: (context) => ChatRoomScreen(
+                roomId: chatRoom.roomId,
+                roomName: chatRoom.roomName ?? '이름 없는 채팅방',
+              ),
+            ),
+          );
+        },
+      ),
     );
   }
 }
@@ -275,6 +290,64 @@ class _ViewModel {
       isLoading: store.state.chatState.isLoading,
       error: store.state.chatState.error,
       chatRooms: store.state.chatState.chatRooms,
+    );
+  }
+}
+
+extension _ChatListScreenExtension on _ChatListScreenState {
+  void _showCreateChatDialog(BuildContext context) {
+    final emailController = TextEditingController();
+    
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('새 대화 시작'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Text('대화할 상대방의 이메일을 입력하세요:'),
+              const SizedBox(height: 16),
+              TextField(
+                controller: emailController,
+                decoration: const InputDecoration(
+                  hintText: 'example@jejunongdi.com',
+                  border: OutlineInputBorder(),
+                ),
+                keyboardType: TextInputType.emailAddress,
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('취소'),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                final email = emailController.text.trim();
+                if (email.isNotEmpty) {
+                  final store = StoreProvider.of<AppState>(context, listen: false);
+                  store.dispatch(GetOrCreateOneToOneRoomAction(email));
+                  Navigator.of(context).pop();
+                } else {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('이메일을 입력해주세요.'),
+                      backgroundColor: Colors.red,
+                    ),
+                  );
+                }
+              },
+              style: ElevatedButton.styleFrom(
+                backgroundColor: const Color(0xFFF2711C),
+                foregroundColor: Colors.white,
+              ),
+              child: const Text('대화 시작'),
+            ),
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/screens/chat_room_screen.dart
+++ b/lib/screens/chat_room_screen.dart
@@ -148,7 +148,7 @@ class _ChatRoomScreenState extends State<ChatRoomScreen> {
                       );
                     }
                     final message = vm.messages[index];
-                    final isMe = vm.myUserId != null && message.sender.id.toString() == vm.myUserId;
+                    final isMe = vm.myUserId != null && message.senderId.id.toString() == vm.myUserId;
                     return _MessageBubble(message: message, isMe: isMe);
                   },
                 );
@@ -268,7 +268,7 @@ class _ViewModel {
     }
     
     for (int i = 0; i < messages.length; i++) {
-      if (messages[i].messageId != other.messages[i].messageId) {
+      if (messages[i].id != other.messages[i].id) {
         print('🔍 _ViewModel 비교: 메시지 ID 다름');
         return false;
       }
@@ -289,7 +289,7 @@ class _ViewModel {
     hasMore,
     myUserId,
     error,
-    messages.map((m) => m.messageId).join(),
+    messages.map((m) => m.id).join(),
   );
 
   static _ViewModel fromStore(Store<AppState> store, String roomId) {
@@ -303,7 +303,7 @@ class _ViewModel {
     
     return _ViewModel(
       isLoading: chatState.isLoading,
-      messages: List.of(messages)..sort((a, b) => b.sentAt.compareTo(a.sentAt)),
+      messages: List.of(messages)..sort((a, b) => b.createdAt.compareTo(a.createdAt)),
       hasMore: chatState.hasMoreMessages[roomId] ?? true,
       myUserId: store.state.userState.user?.id.toString(),
       error: chatState.error,

--- a/lib/screens/job_posting_create_screen.dart
+++ b/lib/screens/job_posting_create_screen.dart
@@ -33,8 +33,8 @@ class _JobPostingCreateScreenState extends State<JobPostingCreateScreen>
   final _contactPhoneController = TextEditingController();
 
   // 주소 관련 변수
-  double _latitude = 33.0;  // 기본값
-  double _longitude = 126.0;  // 기본값
+  double _latitude = 33.5;  // 제주도 중심 기본값
+  double _longitude = 126.5;  // 제주도 중심 기본값
   String _postCode = '';  // 우편번호
 
   // Dropdown & Date Values
@@ -80,7 +80,7 @@ class _JobPostingCreateScreenState extends State<JobPostingCreateScreen>
         address: _addressController.text,  // 직접 TextEditingController에서 가져옴
         wages: int.parse(_wagesController.text),
         recruitmentCount: int.parse(_recruitmentCountController.text),
-        description: _descriptionController.text,
+        description: _descriptionController.text.isNotEmpty ? _descriptionController.text : null,
         cropType: _cropType!,
         workType: _workType!,
         wageType: _wageType!,
@@ -92,6 +92,25 @@ class _JobPostingCreateScreenState extends State<JobPostingCreateScreen>
             ? _contactPhoneController.text
             : null,
       );
+
+      // 🔍 디버그: 전송할 데이터 확인
+      print('🚀 === 공고 등록 요청 데이터 ===');
+      print('📄 JSON: ${request.toJson()}');
+      print('📋 제목: ${request.title}');
+      print('🏠 농장명: ${request.farmName}');
+      print('📍 주소: ${request.address}');
+      print('💰 급여: ${request.wages}');
+      print('👥 모집인원: ${request.recruitmentCount}');
+      print('📝 설명: ${request.description}');
+      print('🌾 작물종류: ${request.cropType}');
+      print('⚒️ 작업종류: ${request.workType}');
+      print('💵 급여종류: ${request.wageType}');
+      print('📅 시작일: ${request.workStartDate}');
+      print('📅 종료일: ${request.workEndDate}');
+      print('🌍 위도: ${request.latitude}');
+      print('🌍 경도: ${request.longitude}');
+      print('📞 연락처: ${request.contactPhone}');
+      print('============================');
 
       final result = await JobPostingService.instance.createJobPosting(request);
 
@@ -345,12 +364,22 @@ class _JobPostingCreateScreenState extends State<JobPostingCreateScreen>
     return Row(
       children: [
         Expanded(
-          child: TextFormField(
-            controller: _addressController,
-            readOnly: true,
-            decoration: _getStyledInputDecoration('주소', _addressController.text.isEmpty ? '탭하여 주소 검색' : null, FontAwesomeIcons.mapLocationDot),
-            validator: (value) => value == null || value.isEmpty ? '주소를 선택해주세요.' : null,
-            onTap: () => _openKpostalView(),
+          child: ValueListenableBuilder<TextEditingValue>(
+            valueListenable: _addressController,
+            builder: (context, value, child) {
+              print('🔄 주소 필드 업데이트: "${value.text}"');
+              return TextFormField(
+                controller: _addressController,
+                readOnly: true,
+                decoration: _getStyledInputDecoration(
+                  '주소', 
+                  _addressController.text.isEmpty ? '탭하여 주소 검색' : null, 
+                  FontAwesomeIcons.mapLocationDot
+                ),
+                validator: (value) => value == null || value.isEmpty ? '주소를 선택해주세요.' : null,
+                onTap: () => _openKpostalView(),
+              );
+            },
           ),
         ),
         const SizedBox(width: 8),
@@ -370,33 +399,51 @@ class _JobPostingCreateScreenState extends State<JobPostingCreateScreen>
     );
   }
 
-  void _openKpostalView() {
-    print('=== 주소 검색 시작 ===');
+  void _openKpostalView() async {
+    print('🔍 === 주소 검색 시작 ===');
+    print('🔑 Kakao Key: ${EnvironmentConfig.kakaoJavascriptKey}');
+    print('📱 현재 context가 mounted: $mounted');
     
-    Navigator.of(context).push(
+    await Navigator.of(context).push(
       MaterialPageRoute(
-        builder: (context) => KpostalView(
-          title: '주소 검색',
-          useLocalServer: false, // 서버 없이 직접 카카오 API 사용
-          kakaoKey: EnvironmentConfig.kakaoJavascriptKey,
-          callback: (Kpostal result) {
-            print('=== 콜백 함수 실행됨 ===');
-            print('선택된 주소: ${result.address}');
-            print('우편번호: ${result.postCode}');
-            print('위도: ${result.latitude}');
-            print('경도: ${result.longitude}');
-            
-            // 화면 닫기
-            Navigator.of(context).pop();
-            
-            // addPostFrameCallback 사용하여 안전하게 상태 업데이트
-            WidgetsBinding.instance.addPostFrameCallback((_) {
+        builder: (context) => Scaffold(
+          appBar: AppBar(
+            title: const Text('주소 검색'),
+            backgroundColor: const Color(0xFFF2711C),
+            foregroundColor: Colors.white,
+          ),
+          body: KpostalView(
+            callback: (Kpostal result) {
+              print('🎯 === 콜백 함수 실행됨 ===');
+              print('📍 선택된 주소: ${result.address}');
+              print('📮 우편번호: ${result.postCode}');
+              print('🌍 위도: ${result.latitude}');
+              print('🌍 경도: ${result.longitude}');
+              print('📱 콜백 시점 mounted: $mounted');
+              
+              // ✅ KPostal이 자동으로 화면을 닫으므로 Navigator.pop() 제거
+              // ✅ 단순하게 setState만 호출 (예제 코드 방식)
               if (mounted) {
+                print('🔄 상태 업데이트 시도...');
                 setState(() {
                   _addressController.text = result.address;
-                  _latitude = result.latitude ?? 33.0;
-                  _longitude = result.longitude ?? 126.0;
+                  
+                  // 🌍 제주도 범위 내 좌표인지 검증 및 조정
+                  double lat = result.latitude ?? 33.5;
+                  double lng = result.longitude ?? 126.5;
+                  
+                  // API 문서 제약 조건: 위도 33.0-34.0, 경도 126.0-127.0
+                  if (lat < 33.0) lat = 33.0;
+                  if (lat > 34.0) lat = 34.0;
+                  if (lng < 126.0) lng = 126.0;
+                  if (lng > 127.0) lng = 127.0;
+                  
+                  _latitude = lat;
+                  _longitude = lng;
                   _postCode = result.postCode;
+                  
+                  print('📝 주소 컨트롤러 업데이트: ${_addressController.text}');
+                  print('🌍 조정된 좌표: 위도=$_latitude, 경도=$_longitude');
                 });
                 
                 // 성공 알림
@@ -407,14 +454,20 @@ class _JobPostingCreateScreenState extends State<JobPostingCreateScreen>
                     duration: const Duration(seconds: 2),
                   ),
                 );
+                print('✅ 상태 업데이트 완료');
+              } else {
+                print('❌ mounted가 false - 위젯이 이미 dispose됨');
               }
-            });
-            
-            print('=== 주소 입력 완료 ===');
-          },
+              
+              print('🏁 === 주소 입력 처리 완료 ===');
+            },
+          ),
         ),
       ),
     );
+    
+    print('🔚 주소 검색 화면에서 돌아옴');
+    print('📝 현재 주소 컨트롤러 값: ${_addressController.text}');
   }
 
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1085,6 +1085,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  stomp_dart_client:
+    dependency: "direct main"
+    description:
+      name: stomp_dart_client
+      sha256: "10ecb6255a95eec78c3b064512fc8700cd2af9506cedafe3694e9662773dd1d5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
   stream_channel:
     dependency: transitive
     description:
@@ -1237,22 +1245,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
-  web_socket:
-    dependency: transitive
-    description:
-      name: web_socket
-      sha256: "34d64019aa8e36bf9842ac014bb5d2f5586ca73df5e4d9bf5c936975cae6982c"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.1"
   web_socket_channel:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: web_socket_channel
-      sha256: d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8
+      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "2.4.0"
   win32:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,6 +59,9 @@ dependencies:
   # New packages for mentoring feature
   url_launcher: ^6.2.5
   image_picker: ^1.1.2
+  # WebSocket and chat functionality
+  stomp_dart_client: ^1.0.0
+  web_socket_channel: ^2.4.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- [X] WebSocket 및 STOMP 프로토콜을 도입하여 실시간 양방향 채팅 기능을 구현했습니다.
- [X] 기존의 HTTP Polling 방식 및 더미 데이터 생성 로직을 제거하고, WebSocket 기반의 실시간 메시지 수신 및 전송 로직으로 대체했습니다.

    주요 변경 사항:
- [X] **WebSocket 서비스 추가:** `WebSocketService`를 신설하여 STOMP 연결, 구독, 메시지 송수신 등 핵심 로직을 캡슐화했습니다.
- [X] **Redux 리팩토링:**
      - WebSocket 연결/해제, 채팅방 입장/퇴장 등 실시간 통신을 위한 새로운 Action 및 Middleware를 추가했습니다.
     - `SendMessageAction`은 WebSocket 연결 상태에 따라 실시간 전송 또는 HTTP API 폴백을 지원하도록 수정했습니다. - 메시지 수신 Reducer(`_receiveMessage`)의 중복 처리 로직을 강화했습니다.
   - [X] **API 모델 및 서비스 개선:** - 백엔드 API 응답 구조 변경에 맞춰 `ChatService`의 데이터 파싱 로직을 강화하고, `data` 필드로 래핑된 응답을 처리하도록 수정했습니다. - 1:1 채팅방 생성을 위한 `OneToOneChatRoomDto` 모델을 추가하고 관련 로직을 업데이트했습니다.
   - [X] **UI/UX 개선:**
     - **채팅 목록:** 스와이프하여 채팅방을 삭제하는 기능을 추가하고, 이메일 입력을 통해 새로운 대화를 시작하는 다이얼로그를 구현했습니다.
     - **채팅방:** 화면 진입 시 WebSocket 연결 및 채팅방 입장이 자동으로 이루어지도록 `onInit` 로직을 개편했습니다. 화면을 벗어날 때 연결이 정리되도록 `dispose` 로직을 개선했습니다. - **채팅 시작 흐름 개선:** 다른 화면(구인공고, 유휴농지 상세)에서 '채팅하기' 버튼 클릭 시, Redux 상태 변경을 감지하여 채팅방이 완전히 생성된 후에만 화면을 이동하도록 로직을 안정화했습니다.
   - [X] **기타:** - 주소 검색(Kpostal) 기능에서 제주도 범위를 벗어나는 좌표를 보정하는 로직을 추가했습니다.

## #️⃣연관된 이슈

> #56 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
